### PR TITLE
Add explicit device mapping for nested contianer

### DIFF
--- a/openvpn.sh
+++ b/openvpn.sh
@@ -2,4 +2,5 @@
 
 docker volume create ovpnkeys
 docker build . -t vpnserver/2.0
-docker run --restart=always --name openvpn -d -v ovpnkeys:/etc/openvpn/keys -p 1194:1194/tcp --cap-add=NET_ADMIN -t vpnserver/2.0
+docker rm -f openvpn
+docker run --restart=always --name openvpn -v ovpnkeys:/etc/openvpn/keys -p 1194:1194/tcp --cap-add=NET_ADMIN --device=/dev/net/tun -t vpnserver/2.0


### PR DESCRIPTION
in the weird edge case where you run docker in docker (or docker in LXC) you have to be explicit about mapping. this fixes that :-) 